### PR TITLE
Add simple reminder app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
+# Reminder App
 
+This repository contains a simple command-line reminder application written in Python.
+
+## Usage
+
+Add a reminder with a due time in ISO format:
+
+```
+python3 reminder_app.py add 2024-05-01T14:30 "Take out the trash"
+```
+
+List all reminders:
+
+```
+python3 reminder_app.py list
+```
+
+Run the reminder loop which checks every 30 seconds and prints due reminders:
+
+```
+python3 reminder_app.py run
+```
+
+Reminders are stored in `reminders.json` in the current directory.

--- a/reminder_app.py
+++ b/reminder_app.py
@@ -1,0 +1,75 @@
+import json
+import os
+import time
+import argparse
+from datetime import datetime
+
+DATA_FILE = "reminders.json"
+
+def load_reminders():
+    if os.path.exists(DATA_FILE):
+        with open(DATA_FILE, "r") as f:
+            return json.load(f)
+    return []
+
+
+def save_reminders(reminders):
+    with open(DATA_FILE, "w") as f:
+        json.dump(reminders, f, indent=2)
+
+
+def add_reminder(args):
+    reminders = load_reminders()
+    due = datetime.fromisoformat(args.time)
+    reminders.append({"time": due.isoformat(), "message": args.message})
+    save_reminders(reminders)
+    print(f"Added reminder for {due}")
+
+
+def list_reminders(args):
+    reminders = load_reminders()
+    if not reminders:
+        print("No reminders set.")
+        return
+    for r in reminders:
+        print(f"{r['time']} - {r['message']}")
+
+
+def run_reminders(args):
+    print("Running reminder loop. Press Ctrl+C to exit.")
+    while True:
+        now = datetime.now()
+        reminders = load_reminders()
+        remaining = []
+        for r in reminders:
+            due = datetime.fromisoformat(r['time'])
+            if due <= now:
+                print(f"Reminder: {r['message']} (due {due})")
+            else:
+                remaining.append(r)
+        if len(remaining) != len(reminders):
+            save_reminders(remaining)
+        time.sleep(30)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple reminder app")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    a = sub.add_parser("add", help="Add a reminder")
+    a.add_argument("time", help="Time in ISO format, e.g. 2024-05-01T14:30")
+    a.add_argument("message", help="Reminder text")
+    a.set_defaults(func=add_reminder)
+
+    l = sub.add_parser("list", help="List reminders")
+    l.set_defaults(func=list_reminders)
+
+    r = sub.add_parser("run", help="Run reminder loop")
+    r.set_defaults(func=run_reminders)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `reminder_app.py` implementing basic CLI reminders stored in JSON
- document how to use the new app in `README.md`

## Testing
- `python3 -m py_compile reminder_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68780842975083298bf615fe4a6ed3f5